### PR TITLE
Rename svd-viewer to peripheral-inspector

### DIFF
--- a/otterdog/eclipse-cdt-cloud.jsonnet
+++ b/otterdog/eclipse-cdt-cloud.jsonnet
@@ -314,6 +314,7 @@ orgs.newOrg('eclipse-cdt-cloud') {
       },
     },
     orgs.newRepo('vscode-svd-viewer') {
+      aliases: ['vscode-peripheral-inspector'],
       allow_merge_commit: true,
       allow_update_branch: false,
       delete_branch_on_merge: false,

--- a/otterdog/eclipse-cdt-cloud.jsonnet
+++ b/otterdog/eclipse-cdt-cloud.jsonnet
@@ -313,8 +313,8 @@ orgs.newOrg('eclipse-cdt-cloud') {
         default_workflow_permissions: "write",
       },
     },
-    orgs.newRepo('vscode-svd-viewer') {
-      aliases: ['vscode-peripheral-inspector'],
+    orgs.newRepo('vscode-peripheral-inspector') {
+      aliases: ['vscode-svd-viewer'],
       allow_merge_commit: true,
       allow_update_branch: false,
       delete_branch_on_merge: false,


### PR DESCRIPTION
To match work undertaken to rename the extension in https://github.com/eclipse-cdt-cloud/vscode-svd-viewer/pull/12