### PR TITLE
Add vscode-clangd repo as fork from clangd/vscode-clangd

### DIFF
--- a/otterdog/eclipse-cdt-cloud.jsonnet
+++ b/otterdog/eclipse-cdt-cloud.jsonnet
@@ -303,6 +303,13 @@ orgs.newOrg('eclipse-cdt-cloud') {
         },
       ],
     },
+    orgs.newRepo('vscode-clangd') {
+      allow_merge_commit: true,
+      allow_update_branch: false,
+      delete_branch_on_merge: true,
+      forked_repository: "clangd/vscode-clangd",
+      web_commit_signoff_required: false,
+    },
     orgs.newRepo('vscode-memory-inspector') {
       allow_merge_commit: true,
       allow_update_branch: false,

--- a/otterdog/eclipse-cdt-cloud.jsonnet
+++ b/otterdog/eclipse-cdt-cloud.jsonnet
@@ -306,6 +306,7 @@ orgs.newOrg('eclipse-cdt-cloud') {
     orgs.newRepo('vscode-clangd') {
       allow_merge_commit: true,
       allow_update_branch: false,
+      default_branch: "master",
       delete_branch_on_merge: true,
       forked_repository: "clangd/vscode-clangd",
       web_commit_signoff_required: false,


### PR DESCRIPTION
As requested in https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/3865.

By default only the default branch will be merged. If you want all branches, we can add:

`
  fork_default_branch_only: false
`

also the name of the forked repo can be different if you want.