### PR TITLE
Allow actions to write in serial monitor repo

### DIFF
--- a/otterdog/eclipse-cdt-cloud.jsonnet
+++ b/otterdog/eclipse-cdt-cloud.jsonnet
@@ -421,7 +421,7 @@ orgs.newOrg('eclipse-cdt-cloud') {
       homepage: "https://open-vsx.org/extension/eclipse-cdt/serial-monitor",
       web_commit_signoff_required: false,
       workflows+: {
-        default_workflow_permissions: "read",
+        default_workflow_permissions: "write",
       },
     },
     orgs.newRepo('website') {


### PR DESCRIPTION
Re: https://github.com/eclipse-cdt-cloud/.eclipsefdn/pull/13#discussion_r1477068760

As expected, read only access for GitHub actions means it cannot create a release entry on GitHub during a release build :(

https://github.com/eclipse-cdt-cloud/vscode-serial-monitor/actions/runs/7847423210

This PR allows the action to write the release.

cc @netomi 