### PR TITLE
Change default workflow permissions of some repos to read

### DIFF
--- a/otterdog/eclipse-cdt-cloud.jsonnet
+++ b/otterdog/eclipse-cdt-cloud.jsonnet
@@ -333,7 +333,7 @@ orgs.newOrg('eclipse-cdt-cloud') {
       homepage: "https://open-vsx.org/extension/eclipse-cdt/memory-inspector",
       web_commit_signoff_required: false,
       workflows+: {
-        default_workflow_permissions: "write",
+        default_workflow_permissions: "read",
       },
     },
     orgs.newRepo('vscode-peripheral-inspector') {
@@ -345,7 +345,7 @@ orgs.newOrg('eclipse-cdt-cloud') {
       homepage: "https://open-vsx.org/extension/eclipse-cdt/peripheral-inspector",
       web_commit_signoff_required: false,
       workflows+: {
-        default_workflow_permissions: "write",
+        default_workflow_permissions: "read",
       },
     },
     orgs.newRepo('vscode-trace-extension') {
@@ -410,7 +410,7 @@ orgs.newOrg('eclipse-cdt-cloud') {
       homepage: "https://open-vsx.org/extension/eclipse-cdt/websocket-adapter",
       web_commit_signoff_required: false,
       workflows+: {
-        default_workflow_permissions: "write",
+        default_workflow_permissions: "read",
       },
     },
     orgs.newRepo('vscode-serial-monitor') {


### PR DESCRIPTION
As discussed in https://github.com/eclipse-cdt-cloud/.eclipsefdn/pull/14#issuecomment-1936666190 we can lock down workflow permissions further and specify what's needed explicitly in the workflow definitions.

This locks down the repos I manage, they have had the permissions added (e.g. https://github.com/eclipse-cdt-cloud/vscode-peripheral-inspector/pull/17)

cc @netomi 