### PR TITLE
Add NPM token to cdt-gdb-adapter

### DIFF
--- a/otterdog/eclipse-cdt-cloud.jsonnet
+++ b/otterdog/eclipse-cdt-cloud.jsonnet
@@ -96,6 +96,11 @@ orgs.newOrg('ecd.cdt-cloud', 'eclipse-cdt-cloud') {
       branch_protection_rules: [
         custom_branch_protection_rule('main'),
       ],
+      secrets: [
+        orgs.newRepoSecret('NPM_AUTH_TOKEN') {
+          value: "pass:bots/ecd.cdt-cloud/npmjs.com/token",
+        },
+      ],
     },
     orgs.newRepo('cdt-gdb-vscode') {
       allow_update_branch: false,


### PR DESCRIPTION
Adds NPM token as secret to `cdt-gdb-adapter` repository.

Required to run GitHub publish flow for cdt-gdb-adapter to NPM. See https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/pull/380

CC: @jonahgraham (project and component lead), @planger (project lead).